### PR TITLE
Add the ability to run the specs on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
-sudo: false
+sudo: required
+dist: trusty
 language: ruby
 rvm:
   - 2.3.1
-before_install: gem install bundler -v 1.13.6
+before_install:
+  - gem install bundler -v 1.13.6
+  - source ${TRAVIS_BUILD_DIR}/ci/before_install.sh
+script:
+  - bundle exec rake spec:setup spec
+addons:
+  postgresql: "9.5"

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -1,0 +1,14 @@
+set -v
+
+sudo sh -c 'echo "deb http://packages.2ndquadrant.com/pglogical/apt/ $(lsb_release -cs)-2ndquadrant main" > /etc/apt/sources.list.d/2ndquadrant.list'
+
+wget --quiet -O - http://packages.2ndquadrant.com/pglogical/apt/AA7A6805.asc | sudo apt-key add -
+sudo apt-get -y update
+sudo apt-get -y upgrade
+sudo apt-get -y install postgresql-9.5-pglogical
+
+echo -e "wal_level = 'logical'\nmax_worker_processes = 10\nmax_replication_slots = 10\nmax_wal_senders = 10\nshared_preload_libraries = 'pglogical'" | sudo tee -a /etc/postgresql/9.5/main/postgresql.conf
+echo -e "local replication all trust" | sudo tee -a /etc/postgresql/9.5/main/pg_hba.conf
+sudo service postgresql restart 9.5
+
+set +v

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -4,7 +4,6 @@ sudo sh -c 'echo "deb http://packages.2ndquadrant.com/pglogical/apt/ $(lsb_relea
 
 wget --quiet -O - http://packages.2ndquadrant.com/pglogical/apt/AA7A6805.asc | sudo apt-key add -
 sudo apt-get -y update
-sudo apt-get -y upgrade
 sudo apt-get -y install postgresql-9.5-pglogical
 
 echo -e "wal_level = 'logical'\nmax_worker_processes = 10\nmax_replication_slots = 10\nmax_wal_senders = 10\nshared_preload_libraries = 'pglogical'" | sudo tee -a /etc/postgresql/9.5/main/postgresql.conf

--- a/spec/pglogical_spec.rb
+++ b/spec/pglogical_spec.rb
@@ -17,10 +17,6 @@ describe "ar_pglogical extension" do
     ActiveRecord::Base.remove_connection
   end
 
-  before do
-    skip "pglogical must be installed" unless connection.pglogical.installed?
-  end
-
   describe "#enable" do
     it "enables the pglogical extension" do
       connection.pglogical.enable

--- a/spec/replication_spec.rb
+++ b/spec/replication_spec.rb
@@ -31,7 +31,6 @@ describe "pglogical replication" do
   end
 
   before do
-    skip "pglogical must be installed" unless source_connection.pglogical.installed?
     create_tables
     enable_nodes
   end


### PR DESCRIPTION
The before_install.sh script installs the proper version of postgres and then installs pglogical based on the distro version we get.

We also need to explicitly specify the spec script because we need to run the setup to create the databases before we run the spec itself.