### PR TITLE
Add the remote and local lsn to the subscription status

### DIFF
--- a/spec/replication_spec.rb
+++ b/spec/replication_spec.rb
@@ -86,6 +86,8 @@ describe "pglogical replication" do
       expect(sub_info["status"]).to eq("replicating")
       expect(sub_info["provider_dsn"]).to eq(source_dsn)
       expect(sub_info["replication_sets"]).to eq([replication_set_name])
+      expect(sub_info["remote_replication_lsn"]).to match(%r{\h+/\h+})
+      expect(sub_info["local_replication_lsn"]).to match(%r{\h+/\h+})
 
       sub_list = target_connection.pglogical.subscriptions
       expect(sub_list.first).to eq(sub_info)


### PR DESCRIPTION
These values can be used to determine replication lag and are directly related to the subscription by the slot name.

A user can use this value to determine the replication lag by using `pg_xlog_location_diff` with the provider node's `pg_current_xlog_insert_location`.