### PR TITLE
Account for symbol table names in drop_table patch

### DIFF
--- a/lib/pg/pglogical/active_record_extension.rb
+++ b/lib/pg/pglogical/active_record_extension.rb
@@ -12,10 +12,12 @@ module PG
 
     module MigrationExtension
       def drop_table(table, options = {})
+        table_string = table.to_s
+
         pgl = PG::Pglogical::Client.new(ApplicationRecord.connection)
         if pgl.enabled?
           pgl.replication_sets.each do |set|
-            pgl.replication_set_remove_table(set, table) if pgl.tables_in_replication_set(set).include?(table)
+            pgl.replication_set_remove_table(set, table_string) if pgl.tables_in_replication_set(set).include?(table_string)
           end
         end
         super


### PR DESCRIPTION
The array of tables names coming from the database contains only
strings.

When comparing the given name to the list we were getting a false
negative result and not removing the table from the replication
set before trying to drop it.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540528