### PR TITLE
Show all subscriptions defined on global region, even if no corresponding node exists on remote

### DIFF
--- a/lib/pg/pglogical/client.rb
+++ b/lib/pg/pglogical/client.rb
@@ -221,7 +221,7 @@ module PG
         sql = <<-SQL
           SELECT sub.*, stat.remote_lsn AS remote_replication_lsn, stat.local_lsn AS local_replication_lsn
           FROM pglogical.show_subscription_status($1) sub
-          JOIN pg_replication_origin_status stat
+          LEFT JOIN pg_replication_origin_status stat
             ON sub.slot_name = stat.external_id
         SQL
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1540688

**Before**:
We were showing only properly set-up subscriptions.
If one of remote node was not set-up properly than  whole UI screen was not loaded.
![before](https://user-images.githubusercontent.com/6556758/35736176-0c562230-07f5-11e8-9d64-7325274a3ccd.png)


**After**:
Show all subscriptions defined on global region, even if no corresponding node exists on remote
<img width="1249" alt="after" src="https://user-images.githubusercontent.com/6556758/35736211-37c7ad76-07f5-11e8-909b-4faff44a0ce6.png">


Issue could be replicated by removing one subscription on global region and immediately adding it back. 

After merging this PR corrupted subscription would be shown without any indication that it is invalid.  I will work on follow-up PR to show subscription status.

@miq-bot add-label bug, replication, gaprindashvili/yes

\cc @carbonin 

