### PR TITLE
Update Rubocop to add compatibility with new rules

### DIFF
--- a/pg-pglogical.gemspec
+++ b/pg-pglogical.gemspec
@@ -29,5 +29,5 @@ EOS
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 0.52"
+  spec.add_development_dependency "rubocop", "~> 0.53"
 end


### PR DESCRIPTION
At [version`0.53.0`](https://github.com/bbatsov/rubocop/blob/3c3e315b84df45845440a25cbd71a5b99214b21d/CHANGELOG.md#0530-2018-03-05), the `TrailingCommaInLiteral` rule at Rubocop has been split into`TrailingCommaInHashLiteral` and `TrailingCommaInArrayLiteral` and no longer exists. The current version definition for Rubocop allow us to use the version `0.52` or superior, but it is not possible to have both versions by having that options in your `rubocop.yml` file.

In order to use the new updated rules, this PR updates the current rubocop version to `0.53`.

Should be merged with:
- https://github.com/ManageIQ/guides/pull/303