### PR TITLE
Removing deprecated Gemnasium badge

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -27,6 +27,7 @@ engines:
   rubocop:
     enabled: true
     config: '.rubocop_cc.yml'
+    channel: 'rubocop-0-69'
 prepare:
   fetch:
   - url: "https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build Status](https://travis-ci.org/ManageIQ/pg-pglogical.svg)](https://travis-ci.org/ManageIQ/pg-pglogical)
 [![Code Climate](https://codeclimate.com/github/ManageIQ/pg-pglogical.svg)](https://codeclimate.com/github/ManageIQ/pg-pglogical)
 [![Test Coverage](https://codeclimate.com/github/ManageIQ/pg-pglogical/badges/coverage.svg)](https://codeclimate.com/github/ManageIQ/pg-pglogical/coverage)
-[![Dependency Status](https://gemnasium.com/ManageIQ/pg-pglogical.svg)](https://gemnasium.com/ManageIQ/pg-pglogical)
 
 This gem extends the ActiveRecord connection object to include methods which map directly to the SQL stored procedure APIs provided by pglogical.
 


### PR DESCRIPTION
Functionality has been replaced by GitHub's dependency graph and security alerts.
Also, added rubocop channel to .codeclimate.yml